### PR TITLE
ENG-1165: add dictation param to streaming demo

### DIFF
--- a/streaming-client.test.ts
+++ b/streaming-client.test.ts
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildStreamingWebSocketUrl,
+  parseStreamingTokenResponse,
+} from './streaming-client.ts';
+
+test('buildStreamingWebSocketUrl includes dictation and auth query params', () => {
+  const url = buildStreamingWebSocketUrl({
+    apiUrl: 'https://api.sully.ai/v1',
+    sampleRate: 16000,
+    encoding: 'linear32',
+    dictation: true,
+    language: 'en-US',
+    accountId: 'acct_123',
+    apiToken: 'token_456',
+  });
+
+  assert.equal(
+    url,
+    'wss://api.sully.ai/v1/audio/transcriptions/stream?sample_rate=16000&encoding=linear32&dictation=true&language=en-US&account_id=acct_123&api_token=token_456',
+  );
+});
+
+test('buildStreamingWebSocketUrl omits optional params when absent', () => {
+  const url = buildStreamingWebSocketUrl({
+    apiUrl: 'http://localhost:4000/v1/',
+    sampleRate: 16000,
+    encoding: 'linear16',
+    dictation: true,
+  });
+
+  assert.equal(
+    url,
+    'ws://localhost:4000/v1/audio/transcriptions/stream?sample_rate=16000&encoding=linear16&dictation=true',
+  );
+});
+
+test('parseStreamingTokenResponse returns a validated token payload', () => {
+  const token = parseStreamingTokenResponse({
+    value: {
+      token: 'token_123',
+      apiUrl: 'https://api.sully.ai/v1',
+      accountId: 'acct_123',
+    },
+  });
+
+  assert.deepEqual(token, {
+    token: 'token_123',
+    apiUrl: 'https://api.sully.ai/v1',
+    accountId: 'acct_123',
+  });
+});
+
+test('parseStreamingTokenResponse rejects invalid payloads', () => {
+  assert.throws(
+    () =>
+      parseStreamingTokenResponse({
+        value: {
+          token: 'token_123',
+          apiUrl: 'https://api.sully.ai/v1',
+        },
+      }),
+    /Invalid streaming token response/,
+  );
+});

--- a/streaming-client.ts
+++ b/streaming-client.ts
@@ -1,0 +1,106 @@
+export interface StreamingToken {
+  token: string;
+  apiUrl: string;
+  accountId: string;
+}
+
+interface BuildStreamingWebSocketUrlParams {
+  apiUrl: string;
+  sampleRate: number;
+  encoding: string;
+  dictation: boolean;
+  language?: string;
+  accountId?: string;
+  apiToken?: string;
+}
+
+const normalizeOptionalString = ({
+  value,
+}: {
+  value?: unknown;
+}): string | undefined => {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const trimmedValue = value.trim();
+  return trimmedValue.length > 0 ? trimmedValue : undefined;
+};
+
+const isStreamingTokenRecord = (
+  value: unknown,
+): value is Record<keyof StreamingToken, string> => {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const token = normalizeOptionalString({
+    value: Reflect.get(value, 'token'),
+  });
+  const apiUrl = normalizeOptionalString({
+    value: Reflect.get(value, 'apiUrl'),
+  });
+  const accountId = normalizeOptionalString({
+    value: Reflect.get(value, 'accountId'),
+  });
+
+  return Boolean(token && apiUrl && accountId);
+};
+
+export const buildStreamingWebSocketUrl = ({
+  apiUrl,
+  sampleRate,
+  encoding,
+  dictation,
+  language,
+  accountId,
+  apiToken,
+}: BuildStreamingWebSocketUrlParams): string => {
+  const websocketBaseUrl = apiUrl
+    .trim()
+    .replace(/\/+$/, '')
+    .replace('https://', 'wss://')
+    .replace('http://', 'ws://');
+
+  const params = new URLSearchParams({
+    sample_rate: `${sampleRate}`,
+    encoding,
+  });
+
+  if (dictation) {
+    params.set('dictation', 'true');
+  }
+
+  const normalizedLanguage = normalizeOptionalString({ value: language });
+  if (normalizedLanguage) {
+    params.set('language', normalizedLanguage);
+  }
+
+  const normalizedAccountId = normalizeOptionalString({ value: accountId });
+  if (normalizedAccountId) {
+    params.set('account_id', normalizedAccountId);
+  }
+
+  const normalizedApiToken = normalizeOptionalString({ value: apiToken });
+  if (normalizedApiToken) {
+    params.set('api_token', normalizedApiToken);
+  }
+
+  return `${websocketBaseUrl}/audio/transcriptions/stream?${params.toString()}`;
+};
+
+export const parseStreamingTokenResponse = ({
+  value,
+}: {
+  value: unknown;
+}): StreamingToken => {
+  if (!isStreamingTokenRecord(value)) {
+    throw new Error('Invalid streaming token response');
+  }
+
+  return {
+    token: value.token,
+    apiUrl: value.apiUrl,
+    accountId: value.accountId,
+  };
+};

--- a/sully-browser-demo.ts
+++ b/sully-browser-demo.ts
@@ -3,6 +3,12 @@
  */
 import { PCMRecorder } from '@speechmatics/browser-audio-input';
 
+import {
+  buildStreamingWebSocketUrl,
+  parseStreamingTokenResponse,
+  type StreamingToken,
+} from './streaming-client.js';
+
 export interface StreamingConfig {
   duration?: number;
   onTranscription?: (text: string) => void;
@@ -13,11 +19,8 @@ export interface StreamingConfig {
   ) => void;
 }
 
-interface StreamingToken {
-  token: string;
-  apiUrl: string;
-  accountId: string;
-}
+const toError = ({ value }: { value: unknown }): Error =>
+  value instanceof Error ? value : new Error(String(value));
 
 export class SullyStreamingDemo {
   private ws: WebSocket | null = null;
@@ -28,7 +31,6 @@ export class SullyStreamingDemo {
   private retryTimeoutId: ReturnType<typeof setTimeout> | null = null;
   private countdownIntervalId: ReturnType<typeof setInterval> | null = null;
   private userStopped = false;
-  private streamingToken: { token: string; apiUrl: string; accountId: string } | null = null;
   private config: StreamingConfig;
   private segments: { text: string; isFinal: boolean }[] = [];
   private currentSegmentIndex: number = 0;
@@ -52,7 +54,6 @@ export class SullyStreamingDemo {
 
     this.userStopped = false;
     this.retryCount = 0;
-    this.streamingToken = null;
 
     try {
       this.segments = []; // Reset segments
@@ -61,21 +62,7 @@ export class SullyStreamingDemo {
       this.config.onStatusChange?.('starting');
       // Get streaming token from server
       console.log('Requesting streaming token from server...');
-      const tokenResponse = await fetch('/streaming-token', {
-        method: 'POST',
-      });
-
-      if (!tokenResponse.ok) {
-        console.error(
-          `Token request failed with status: ${tokenResponse.status}`,
-        );
-        this.config.onStatusChange?.('error');
-        throw new Error('Failed to get streaming token');
-      }
-
-      const { token, apiUrl, accountId } =
-        (await tokenResponse.json()) as StreamingToken;
-      this.streamingToken = { token, apiUrl, accountId };
+      const { token, apiUrl, accountId } = await this.fetchStreamingToken();
       console.log('Successfully obtained streaming token');
 
       // Initialize WebSocket connection
@@ -107,7 +94,7 @@ export class SullyStreamingDemo {
       }
     } catch (error) {
       console.error('Error in start():', error);
-      this.handleError(error as Error);
+      this.handleError(toError({ value: error }));
     }
   }
 
@@ -162,14 +149,7 @@ export class SullyStreamingDemo {
       if (this.userStopped) return;
       try {
         // Always re-fetch token — old one may have expired
-        const tokenResponse = await fetch('/streaming-token', { method: 'POST' });
-        if (!tokenResponse.ok) throw new Error('Failed to refresh streaming token');
-        const data = await tokenResponse.json() as { token?: string; apiUrl?: string; accountId?: string };
-        if (!data.token || !data.apiUrl || !data.accountId) {
-          throw new Error('Invalid token response: missing required fields');
-        }
-        const { token, apiUrl, accountId } = data as { token: string; apiUrl: string; accountId: string };
-        this.streamingToken = { token, apiUrl, accountId };
+        const { token, apiUrl, accountId } = await this.fetchStreamingToken();
 
         await this.initializeWebSocket(token, apiUrl, accountId);
         this.config.onStatusChange?.('connected');
@@ -203,19 +183,21 @@ export class SullyStreamingDemo {
     apiUrl: string,
     accountId: string,
   ): Promise<void> {
-    const wsUrl = apiUrl
-      .replace('https://', 'wss://')
-      .replace('http://', 'ws://');
-
-    // linear32 = Float32Array natively from PCMRecorder, no conversion needed
-    const params = new URLSearchParams({
-      sample_rate: '16000',
+    const fullUrl = buildStreamingWebSocketUrl({
+      apiUrl,
+      sampleRate: 16000,
       encoding: 'linear32',
-      account_id: accountId,
-      api_token: token,
+      dictation: true,
+      accountId,
+      apiToken: token,
     });
-    const fullUrl = `${wsUrl}/audio/transcriptions/stream?${params.toString()}`;
-    console.log('Connecting to WebSocket:', wsUrl);
+    const loggedUrl = buildStreamingWebSocketUrl({
+      apiUrl,
+      sampleRate: 16000,
+      encoding: 'linear32',
+      dictation: true,
+    });
+    console.log('Connecting to WebSocket:', loggedUrl);
 
     this.ws = new WebSocket(fullUrl);
 
@@ -270,7 +252,7 @@ export class SullyStreamingDemo {
         }
       } catch (error) {
         console.error('Error parsing transcription message:', error);
-        this.handleError(error as Error);
+        this.handleError(toError({ value: error }));
       }
     };
 
@@ -322,6 +304,22 @@ export class SullyStreamingDemo {
       binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
     }
     return btoa(binary);
+  }
+
+  private async fetchStreamingToken(): Promise<StreamingToken> {
+    const tokenResponse = await fetch('/streaming-token', {
+      method: 'POST',
+    });
+
+    if (!tokenResponse.ok) {
+      throw new Error(
+        `Failed to get streaming token (${tokenResponse.status})`,
+      );
+    }
+
+    return parseStreamingTokenResponse({
+      value: await tokenResponse.json(),
+    });
   }
 
   private handleError(error: Error): void {

--- a/sully-demo.ts
+++ b/sully-demo.ts
@@ -8,6 +8,8 @@ import fetch from 'node-fetch';
 import mic from 'node-microphone'; // For microphone access
 import WebSocket from 'ws'; // For real-time audio streaming
 
+import { buildStreamingWebSocketUrl } from './streaming-client.js';
+
 // Load environment variables from .env file
 dotenv.config();
 
@@ -272,31 +274,23 @@ async function demonstrateStreaming({
     token = tokenReq.data.token;
   }
 
-  // Convert HTTP/HTTPS URL to WebSocket URL
-  const baseWsUrl =
-    SULLY_API_URL.replace('https://', 'wss://').replace('http://', 'ws://') +
-    '/v1/audio/transcriptions/stream';
-
-  // Build query parameters
-  const params = new URLSearchParams({
-    sample_rate: '16000',
+  // Build the shared streaming URL once so CLI and browser stay in sync.
+  const streamConnectionParams = {
+    apiUrl: `${SULLY_API_URL}/v1`,
+    sampleRate: 16000,
     encoding: 'linear16',
+    dictation: true,
+    language,
+  } as const;
+
+  const wsUrl = buildStreamingWebSocketUrl({
+    ...streamConnectionParams,
+    accountId: token ? ACCOUNT_ID : undefined,
+    apiToken: token,
   });
+  const loggedWsUrl = buildStreamingWebSocketUrl(streamConnectionParams);
 
-  // Add language parameter if provided
-  if (language) {
-    params.append('language', language);
-  }
-
-  // Add authentication parameters for client mode
-  if (token) {
-    params.append('account_id', ACCOUNT_ID);
-    params.append('api_token', token);
-  }
-
-  const wsUrl = `${baseWsUrl}?${params.toString()}`;
-
-  logger.info(`Connecting to WebSocket: ${wsUrl}`);
+  logger.info(`Connecting to WebSocket: ${loggedWsUrl}`);
 
   return new Promise((resolve, reject) => {
     try {


### PR DESCRIPTION
## Summary

Add the dictation query param to the demo streaming clients and clean up the duplicated connection setup so the CLI and browser stay in sync.

## Changes

- add `dictation=true` to both CLI and browser streaming WebSocket URLs
- extract shared streaming URL construction and token response parsing into `streaming-client.ts`
- remove duplicate browser token fetch/validation logic and dead token state
- add regression coverage for streaming URL/query construction and token parsing

## Testing

- node --experimental-strip-types --test streaming-client.test.ts